### PR TITLE
Update CSqlite.php

### DIFF
--- a/plugins/CSqlite.php
+++ b/plugins/CSqlite.php
@@ -142,8 +142,9 @@ EOD;
 		else
 		{
 			$vPwdHash = password_hash($vPwd, PASSWORD_DEFAULT);
-			file_put_contents($this->aConf['vPwdFile'], $vPwdHash) ||
+			if (!file_put_contents($this->aConf['vPwdFile'], $vPwdHash)) {
 				throw new Error("Can't write password file ($this->aConf['vPwdFile'])");
+			}
 			$vPwd = '';
 		}
 		return [Adminer\SERVER, $_GET["username"], $vPwd];


### PR DESCRIPTION
Fixes:
`PHP Parse error:  syntax error, unexpected 'throw' (T_THROW) in /var/www/adminer/plugins/CSqlite.php on line 146
`